### PR TITLE
.do.check also fires change event

### DIFF
--- a/lib/do.js
+++ b/lib/do.js
@@ -522,6 +522,12 @@ functions.push([
 
         element.checked = !element.checked;
 
+        // Fire change event
+
+        var event = document.createEvent('HTMLEvents');
+        event.initEvent('change', true, true);
+        element.dispatchEvent(event);
+
         return true;
       }, function (err, exists) {
         if (err) {


### PR DESCRIPTION
Firing change event for consistency with #15.

Other methods don't seem to need it:
- `.do.upload` delegates to PhantomJS `uploadFile`, though I haven't got a change to test that yet
- `.do.type` is not required to fire change events as it normally happens on blur
